### PR TITLE
Add audio processing option

### DIFF
--- a/app/components/ComplexComponents/MetadataForm.tsx
+++ b/app/components/ComplexComponents/MetadataForm.tsx
@@ -559,18 +559,6 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({
                   multiline
                 />
               </div>
-              {metadata.extractedText && (
-                <div>
-                  <label className="font-bold">
-                    {t("metadataForm.fields.extractedText")}
-                  </label>
-                  <div className="mt-1 p-2 border-4 border-black rounded-lg bg-gray-100 max-h-40 overflow-y-auto">
-                    <p className="whitespace-pre-wrap text-sm">
-                      {metadata.extractedText}
-                    </p>
-                  </div>
-                </div>
-              )}
             </div>
           )}
         </>

--- a/app/components/ComplexComponents/ProcessOptions.tsx
+++ b/app/components/ComplexComponents/ProcessOptions.tsx
@@ -78,7 +78,6 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
           "keywords",
           "content_type",
           "multilingual",
-          "extractedText",
         ]);
         break;
       case "image_description":
@@ -107,6 +106,22 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
           "multilingual",
         ]);
         break;
+      case "audio":
+        setRenderFields([
+          "author",
+          "title",
+          "content",
+          "tags",
+          "sentiment",
+          "work",
+          "languages",
+          "analysis",
+          "categories",
+          "keywords",
+          "content_type",
+          "multilingual",
+        ]);
+        break;
       default:
         setRenderFields([]);
         break;
@@ -120,7 +135,8 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
       );
     } else if (
       activeProcessingMethod === "ocr" ||
-      activeProcessingMethod === "llm"
+      activeProcessingMethod === "llm" ||
+      activeProcessingMethod === "audio"
     ) {
       return llmModelOptions.filter(
         (model) =>
@@ -189,6 +205,8 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
                 ? t("processOptions.ocr")
                 : option === "image_description"
                 ? t("processOptions.imageDescription")
+                : option === "audio"
+                ? t("processOptions.audio")
                 : option === "llm"
                 ? t("processOptions.llm")
                 : t("processOptions.manual")}
@@ -271,7 +289,8 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
               </BrutalButton>
             )}
             {(activeProcessingMethod === "llm" ||
-              activeProcessingMethod === "image_description") && (
+              activeProcessingMethod === "image_description" ||
+              activeProcessingMethod === "audio") && (
               <BrutalButton
                 onClick={() =>
                   processWithLLM(activeProcessingMethod as TaskType)

--- a/app/utils/categorizerAPI.ts
+++ b/app/utils/categorizerAPI.ts
@@ -64,9 +64,14 @@ export interface OCRResult {
 }
 
 // Tipos extra
-export type TaskType = "text" | "image_description" | "ocr";
+export type TaskType = "text" | "image_description" | "ocr" | "audio";
 export type OCRMethod = "tesseract" | "llm";
-export type ProcessingMethod = "manual" | "llm" | "ocr" | "image_description";
+export type ProcessingMethod =
+  | "manual"
+  | "llm"
+  | "ocr"
+  | "image_description"
+  | "audio";
 
 // Interfaz para la creación de relaciones
 export interface CreateRelationshipData {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -56,6 +56,7 @@
     "ocr": "OCR",
     "llm": "LLM",
     "imageDescription": "Image Description",
+    "audio": "Audio/Music",
     "model": "Model",
     "temperature": "Temperature",
     "processWithLLM": "Process with LLM",
@@ -85,8 +86,7 @@
       "topics": "Topics",
       "style": "Style",
       "color_palette": "Color Palette",
-      "composition": "Composition",
-      "extractedText": "Extracted Text"
+      "composition": "Composition"
     },
     "placeholders": {
       "title": "Content title",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -56,6 +56,7 @@
     "ocr": "OCR",
     "llm": "LLM",
     "imageDescription": "Descripción de Imagen",
+    "audio": "Audio/Música",
     "model": "Modelo",
     "temperature": "Temperatura",
     "processWithLLM": "Procesar con LLM",
@@ -85,8 +86,7 @@
       "topics": "Temas (topics)",
       "style": "Estilo (style)",
       "color_palette": "Paleta de Colores",
-      "composition": "Composición (composition)",
-      "extractedText": "Texto Extraído"
+      "composition": "Composición (composition)"
     },
     "placeholders": {
       "title": "Título del contenido",


### PR DESCRIPTION
## Summary
- add new TaskType and ProcessingMethod for audio files
- extend processing options UI with audio option and model filtering
- default audio files to audio processing method
- handle audio processing in backend API calls
- add translations for audio option in English and Spanish
- handle extracted text as content instead of a separate field

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b80bd5288322ae5b23ebb27bb565