### PR TITLE
Add audio/video search options

### DIFF
--- a/app/utils/categorizerAPI.ts
+++ b/app/utils/categorizerAPI.ts
@@ -477,8 +477,11 @@ class CategorizerAPI {
     const form = new FormData();
     Object.entries(payload).forEach(([k, v]) => {
       if (v === undefined || v === null) return;
-      if (k === "file" && v instanceof File) form.append("file", v);
-      else form.append(k, String(v));
+      if (v instanceof File) {
+        form.append(k, v);
+      } else {
+        form.append(k, String(v));
+      }
     });
 
     try {


### PR DESCRIPTION
## Summary
- support File objects for any key in `multimodalSearch`
- support audio and video search inputs in RAG UI

## Testing
- `npm run lint` *(fails: Failed to load config "./node_modules/ts-standard/eslintrc.json" to extend from)*
- `npm run build` *(fails: failed to fetch fonts from Google due to networking restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688c11daa9cc832296528f3945cee326