### PR TITLE
Add video processing option

### DIFF
--- a/app/components/ComplexComponents/ProcessOptions.tsx
+++ b/app/components/ComplexComponents/ProcessOptions.tsx
@@ -122,6 +122,23 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
           "multilingual",
         ]);
         break;
+      case "video":
+        setRenderFields([
+          "description",
+          "author",
+          "title",
+          "content",
+          "tags",
+          "sentiment",
+          "work",
+          "languages",
+          "analysis",
+          "categories",
+          "keywords",
+          "content_type",
+          "multilingual",
+        ]);
+        break;
       default:
         setRenderFields([]);
         break;
@@ -136,7 +153,8 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
     } else if (
       activeProcessingMethod === "ocr" ||
       activeProcessingMethod === "llm" ||
-      activeProcessingMethod === "audio"
+      activeProcessingMethod === "audio" ||
+      activeProcessingMethod === "video"
     ) {
       return llmModelOptions.filter(
         (model) =>
@@ -207,6 +225,8 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
                 ? t("processOptions.imageDescription")
                 : option === "audio"
                 ? t("processOptions.audio")
+                : option === "video"
+                ? t("processOptions.video")
                 : option === "llm"
                 ? t("processOptions.llm")
                 : t("processOptions.manual")}
@@ -290,7 +310,8 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
             )}
             {(activeProcessingMethod === "llm" ||
               activeProcessingMethod === "image_description" ||
-              activeProcessingMethod === "audio") && (
+              activeProcessingMethod === "audio" ||
+              activeProcessingMethod === "video") && (
               <BrutalButton
                 onClick={() =>
                   processWithLLM(activeProcessingMethod as TaskType)

--- a/app/processing/page.tsx
+++ b/app/processing/page.tsx
@@ -155,6 +155,8 @@ export default function ProcessFiles() {
         defaultProcessingMethod = "llm";
       } else if (mainType === "audio") {
         defaultProcessingMethod = "audio";
+      } else if (mainType === "video") {
+        defaultProcessingMethod = "video";
       }
 
       // Determinar default embedding type
@@ -224,6 +226,8 @@ export default function ProcessFiles() {
           defaultProcessingMethod = "llm";
         } else if (mainType === "audio") {
           defaultProcessingMethod = "audio";
+        } else if (mainType === "video") {
+          defaultProcessingMethod = "video";
         }
 
         // Determinar default embedding type
@@ -275,7 +279,7 @@ export default function ProcessFiles() {
       case "image":
         return ["ocr", "image_description", "manual"];
       case "video":
-        return ["llm", "manual"];
+        return ["video", "manual"];
       case "audio":
         return ["audio", "manual"];
       case "application":
@@ -406,6 +410,12 @@ export default function ProcessFiles() {
           file_url: currentFile.file_url,
           ...commonLLMOptions,
         });
+      } else if (taskType === "video") {
+        result = await categorizerAPI.processLLM({
+          task: "video",
+          file_url: currentFile.file_url,
+          ...commonLLMOptions,
+        });
       }
 
       if (result) {
@@ -426,7 +436,8 @@ export default function ProcessFiles() {
           if (
             taskType === "ocr" ||
             taskType === "text" ||
-            taskType === "audio"
+            taskType === "audio" ||
+            taskType === "video"
           ) {
             if (autoFields.title)
               updates.title = mergeField(existingMetadata.title, llmData.title);
@@ -467,6 +478,12 @@ export default function ProcessFiles() {
               llmData.multilingual !== undefined
                 ? llmData.multilingual
                 : existingMetadata.multilingual;
+            if (taskType === "video" && autoFields.description) {
+              updates.description = mergeField(
+                existingMetadata.description,
+                llmData.description
+              );
+            }
             // extracted text is merged into the content field
           } else if (taskType === "image_description") {
             if (autoFields.description)

--- a/app/utils/categorizerAPI.ts
+++ b/app/utils/categorizerAPI.ts
@@ -64,14 +64,20 @@ export interface OCRResult {
 }
 
 // Tipos extra
-export type TaskType = "text" | "image_description" | "ocr" | "audio";
+export type TaskType =
+  | "text"
+  | "image_description"
+  | "ocr"
+  | "audio"
+  | "video";
 export type OCRMethod = "tesseract" | "llm";
 export type ProcessingMethod =
   | "manual"
   | "llm"
   | "ocr"
   | "image_description"
-  | "audio";
+  | "audio"
+  | "video";
 
 // Interfaz para la creación de relaciones
 export interface CreateRelationshipData {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -57,6 +57,7 @@
     "llm": "LLM",
     "imageDescription": "Image Description",
     "audio": "Audio/Music",
+    "video": "Video",
     "model": "Model",
     "temperature": "Temperature",
     "processWithLLM": "Process with LLM",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -57,6 +57,7 @@
     "llm": "LLM",
     "imageDescription": "Descripción de Imagen",
     "audio": "Audio/Música",
+    "video": "Video",
     "model": "Modelo",
     "temperature": "Temperatura",
     "processWithLLM": "Procesar con LLM",


### PR DESCRIPTION
## Summary
- support `video` in processing options for Next.js frontend
- update type definitions to include `video`
- add translations for new option

## Testing
- `npm run lint` *(fails: Failed to load config "./node_modules/ts-standard/eslintrc.json" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_688c525f25648322ab0b3927bb0217a4