### PR TITLE
feat: add video metadata fields

### DIFF
--- a/app/components/ComplexComponents/MetadataForm.tsx
+++ b/app/components/ComplexComponents/MetadataForm.tsx
@@ -465,8 +465,99 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({
             // ... General/Manual Form Fields ...
             <div className="space-y-4 border-4 border-black rounded-lg p-4 bg-white">
               <h3 className="text-xl font-bold">
-                {t("metadataForm.generalTitle")}
+                {metadata.processingMethod === "video"
+                  ? t("metadataForm.videoTitle")
+                  : t("metadataForm.generalTitle")}
               </h3>
+              {metadata.processingMethod === "video" && (
+                <>
+                  <div>
+                    <label className="font-bold">
+                      {t("metadataForm.fields.description")}
+                    </label>
+                    <BrutalInput
+                      type="textarea"
+                      placeholder={t("metadataForm.placeholders.description")}
+                      value={metadata.description || ""}
+                      onChange={(e) =>
+                        updateMetadata({ description: e.target.value })
+                      }
+                      className="w-full p-2 border-4 border-black rounded-lg h-32"
+                      multiline
+                    />
+                  </div>
+                  <div>
+                    <label className="font-bold">
+                      {t("metadataForm.fields.topics")}
+                    </label>
+                    <BrutalInput
+                      type="text"
+                      placeholder={t("metadataForm.placeholders.topics")}
+                      value={(metadata.topics || []).join(", ")}
+                      onChange={(e) =>
+                        updateMetadata({
+                          topics: e.target.value
+                            .split(",")
+                            .map((t) => t.trim()),
+                        })
+                      }
+                      className="w-full p-2 border-4 border-black rounded-lg"
+                    />
+                  </div>
+                  <div>
+                    <label className="font-bold">
+                      {t("metadataForm.fields.style")}
+                    </label>
+                    <BrutalInput
+                      type="text"
+                      placeholder={t("metadataForm.placeholders.style")}
+                      value={metadata.style || ""}
+                      onChange={(e) => updateMetadata({ style: e.target.value })}
+                      className="w-full p-2 border-4 border-black rounded-lg"
+                    />
+                  </div>
+                  <div>
+                    <label className="font-bold">
+                      {t("metadataForm.fields.color_palette")}
+                    </label>
+                    <BrutalInput
+                      type="text"
+                      placeholder={t("metadataForm.placeholders.color_palette")}
+                      value={(metadata.color_palette || []).join(", ")}
+                      onChange={(e) =>
+                        updateMetadata({
+                          color_palette: e.target.value
+                            .split(",")
+                            .map((c) => c.trim()),
+                        })
+                      }
+                      className="w-full p-2 border-4 border-black rounded-lg"
+                    />
+                  </div>
+                  <div>
+                    <label className="font-bold">
+                      {t("metadataForm.fields.frame_descriptions")}
+                    </label>
+                    <BrutalInput
+                      type="textarea"
+                      placeholder={t(
+                        "metadataForm.placeholders.frame_descriptions"
+                      )}
+                      value={(metadata.frame_descriptions || []).join("\n")}
+                      onChange={(e) =>
+                        updateMetadata({
+                          frame_descriptions: e.target.value
+                            .split("\n")
+                            .map((f) => f.trim())
+                            .filter(Boolean),
+                        })
+                      }
+                      className="w-full p-2 border-4 border-black rounded-lg h-32"
+                      multiline
+                    />
+                  </div>
+                </>
+              )}
               <div>
                 <label className="font-bold">
                   {t("metadataForm.fields.author")}

--- a/app/components/ComplexComponents/ProcessOptions.tsx
+++ b/app/components/ComplexComponents/ProcessOptions.tsx
@@ -22,6 +22,7 @@ interface AutoFields {
   topics: boolean;
   style: boolean;
   color_palette: boolean;
+  frame_descriptions: boolean;
   composition: boolean;
 }
 
@@ -124,6 +125,10 @@ export const ProcessOptions: React.FC<ProcessOptionsProps> = ({
       case "video":
         setRenderFields([
           "description",
+          "topics",
+          "style",
+          "color_palette",
+          "frame_descriptions",
           "author",
           "title",
           "content",

--- a/app/processing/page.tsx
+++ b/app/processing/page.tsx
@@ -46,6 +46,7 @@ export type ProcessingFileMetadata = {
   topics?: string[];
   style?: string;
   color_palette?: string[];
+  frame_descriptions?: string[];
   composition?: string;
   file_type?: string;
 };
@@ -62,6 +63,7 @@ interface AutoFields {
   topics: boolean;
   style: boolean;
   color_palette: boolean;
+  frame_descriptions: boolean;
   composition: boolean;
 }
 
@@ -94,6 +96,7 @@ export default function ProcessFiles() {
     topics: true,
     style: true,
     color_palette: true,
+    frame_descriptions: true,
     composition: true,
   });
   const [selectedMethodForUI, setSelectedMethodForUI] =
@@ -488,11 +491,32 @@ export default function ProcessFiles() {
               llmData.multilingual !== undefined
                 ? llmData.multilingual
                 : existingMetadata.multilingual;
-            if (taskType === "video" && autoFields.description) {
-              updates.description = mergeField(
-                existingMetadata.description,
-                llmData.description
-              );
+            if (taskType === "video") {
+              if (autoFields.description)
+                updates.description = mergeField(
+                  existingMetadata.description,
+                  llmData.description
+                );
+              if (autoFields.topics)
+                updates.topics = mergeArrayField(
+                  existingMetadata.topics,
+                  llmData.topics
+                );
+              if (autoFields.style)
+                updates.style = mergeField(
+                  existingMetadata.style,
+                  llmData.style
+                );
+              if (autoFields.color_palette)
+                updates.color_palette = mergeArrayField(
+                  existingMetadata.color_palette,
+                  llmData.color_palette
+                );
+              if (autoFields.frame_descriptions)
+                updates.frame_descriptions = mergeArrayField(
+                  existingMetadata.frame_descriptions,
+                  llmData.frame_descriptions
+                );
             }
             // extracted text is merged into the content field
           } else if (taskType === "image_description") {

--- a/app/text-processing/page.tsx
+++ b/app/text-processing/page.tsx
@@ -56,6 +56,12 @@ interface AutoFields {
   sentiment_word: boolean;
   sentiment_value: boolean;
   languages: boolean;
+  description: boolean;
+  topics: boolean;
+  style: boolean;
+  color_palette: boolean;
+  frame_descriptions: boolean;
+  composition: boolean;
 }
 
 /**
@@ -251,6 +257,12 @@ export default function ProcessTexts() {
     languages: true,
     sentiment_word: true,
     sentiment_value: true,
+    description: true,
+    topics: true,
+    style: true,
+    color_palette: true,
+    frame_descriptions: true,
+    composition: true,
   });
 
   // Config LLM (modelo, temperatura)

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -73,6 +73,7 @@
     "ocrTitle": "OCR Metadata",
     "imageTitle": "Image Analysis Metadata",
     "generalTitle": "General/Manual Metadata",
+    "videoTitle": "Video Analysis Metadata",
     "fields": {
       "title": "Title",
       "author": "Author",
@@ -92,7 +93,8 @@
       "topics": "Topics",
       "style": "Style",
       "color_palette": "Color Palette",
-      "composition": "Composition"
+      "composition": "Composition",
+      "frame_descriptions": "Frame Descriptions"
     },
     "placeholders": {
       "title": "Content title",
@@ -110,6 +112,7 @@
       "style": "Visual style description",
       "color_palette": "Colors separated by comma (optional)",
       "composition": "Notes about image composition",
+      "frame_descriptions": "Frame descriptions separated by newline",
       "regularContent": "File content",
       "analysis": "In-depth content analysis"
     }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -73,6 +73,7 @@
     "ocrTitle": "Metadatos OCR",
     "imageTitle": "Metadatos - Análisis de Imagen",
     "generalTitle": "Metadatos Generales / Manual",
+    "videoTitle": "Metadatos - Análisis de Video",
     "fields": {
       "title": "Título",
       "author": "Autor",
@@ -92,7 +93,8 @@
       "topics": "Temas (topics)",
       "style": "Estilo (style)",
       "color_palette": "Paleta de Colores",
-      "composition": "Composición (composition)"
+      "composition": "Composición (composition)",
+      "frame_descriptions": "Descripciones de fotogramas"
     },
     "placeholders": {
       "title": "Título del contenido",
@@ -110,6 +112,7 @@
       "style": "Descripción del estilo visual",
       "color_palette": "Colores separados por coma (opcional)",
       "composition": "Notas sobre la composición de la imagen",
+      "frame_descriptions": "Descripciones por fotograma separadas por línea",
       "regularContent": "Contenido del archivo",
       "analysis": "Análisis profundo del contenido"
     }


### PR DESCRIPTION
## Summary
- support video-specific metadata like frame descriptions, color palette, topics, and style
- capture new video fields in processing pipeline and UI
- add translations for video metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to load config "./node_modules/ts-standard/eslintrc.json" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_688f96a352148322bcb224c630e00a3e