### PR TITLE
feat: add audio metadata fields

### DIFF
--- a/app/components/ComplexComponents/MetadataForm.tsx
+++ b/app/components/ComplexComponents/MetadataForm.tsx
@@ -461,6 +461,73 @@ export const MetadataForm: React.FC<MetadataFormProps> = ({
                 />
               </div>
             </div>
+          ) : metadata.processingMethod === "audio" ? (
+            <div className="space-y-4 border-4 border-black rounded-lg p-4 bg-white">
+              <h3 className="text-xl font-bold">
+                {t("metadataForm.audioTitle")}
+              </h3>
+              <div>
+                <label className="font-bold">
+                  {t("metadataForm.fields.description")}
+                </label>
+                <BrutalInput
+                  type="textarea"
+                  placeholder={t("metadataForm.placeholders.description")}
+                  value={metadata.description || ""}
+                  onChange={(e) =>
+                    updateMetadata({ description: e.target.value })
+                  }
+                  className="w-full p-2 border-4 border-black rounded-lg h-32"
+                  multiline
+                />
+              </div>
+              <div>
+                <label className="font-bold">
+                  {t("metadataForm.fields.author")}
+                </label>
+                <BrutalInput
+                  type="text"
+                  placeholder={t("metadataForm.placeholders.author")}
+                  value={metadata.author || ""}
+                  onChange={(e) => updateMetadata({ author: e.target.value })}
+                  className="w-full p-2 border-4 border-black rounded-lg"
+                />
+              </div>
+              <div>
+                <label className="font-bold">
+                  {t("metadataForm.fields.title")}
+                </label>
+                <BrutalInput
+                  type="text"
+                  placeholder={t("metadataForm.placeholders.title")}
+                  value={metadata.title || ""}
+                  onChange={(e) => updateMetadata({ title: e.target.value })}
+                  className="w-full p-2 border-4 border-black rounded-lg"
+                />
+              </div>
+              <div>
+                <label className="font-bold">
+                  {t("metadataForm.fields.tags")}
+                </label>
+                {renderTagSection(metadata.tags || [], addTag, removeTag)}
+              </div>
+              <div>
+                <label className="font-bold">
+                  {t("metadataForm.fields.topics")}
+                </label>
+                <BrutalInput
+                  type="text"
+                  placeholder={t("metadataForm.placeholders.topics")}
+                  value={(metadata.topics || []).join(", ")}
+                  onChange={(e) =>
+                    updateMetadata({
+                      topics: e.target.value.split(",").map((t) => t.trim()),
+                    })
+                  }
+                  className="w-full p-2 border-4 border-black rounded-lg"
+                />
+              </div>
+            </div>
           ) : (
             // ... General/Manual Form Fields ...
             <div className="space-y-4 border-4 border-black rounded-lg p-4 bg-white">

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -73,6 +73,7 @@
     "ocrTitle": "OCR Metadata",
     "imageTitle": "Image Analysis Metadata",
     "generalTitle": "General/Manual Metadata",
+    "audioTitle": "Audio Analysis Metadata",
     "videoTitle": "Video Analysis Metadata",
     "fields": {
       "title": "Title",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -73,6 +73,7 @@
     "ocrTitle": "Metadatos OCR",
     "imageTitle": "Metadatos - Análisis de Imagen",
     "generalTitle": "Metadatos Generales / Manual",
+    "audioTitle": "Metadatos - Análisis de Audio",
     "videoTitle": "Metadatos - Análisis de Video",
     "fields": {
       "title": "Título",


### PR DESCRIPTION
## Summary
- add dedicated audio metadata form with author and title fields
- localize audio metadata title in English and Spanish

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to load config "./node_modules/ts-standard/eslintrc.json" to extend from.)

------
https://chatgpt.com/codex/tasks/task_e_688fa4b1b4c083229c5ce82ceb587780